### PR TITLE
fix crash in std::vector due to illegal negative index

### DIFF
--- a/src/generic/maskededit.cpp
+++ b/src/generic/maskededit.cpp
@@ -959,7 +959,7 @@ void wxMaskedEdit::OnChar(wxKeyEvent& event)
 
         //May jump to next field
         size_t inField = (size_t) FindField(caretPos);
-        if ( caretPos == m_arrPosF[inField] && !HasFieldRoom(inField) )
+        if ( inField != wxNOT_FOUND && caretPos == m_arrPosF[inField] && !HasFieldRoom(inField) )
         {
             long defPos = PosForFieldNext(caretPos);
             //If we have inserted at last position, keep the caret at its end.


### PR DESCRIPTION
fix crash in std::vector due to illegal negative index (which is in fact an error code returned by FindField().

How this failure was produced:

- start maskedctrl sample app
- click on second part of IPv4 edit field, just before the '0'
- type: '1' (field should still be red and now show `192.10.`
- type '.' --> crash instead of jump to next part of the IP address.